### PR TITLE
Fix Undici security vulnerabilities

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5624,23 +5624,6 @@
         "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
       }
     },
-    "node_modules/@ngtools/webpack": {
-      "version": "21.2.17",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-21.2.17.tgz",
-      "integrity": "sha512-HYh6YUl/sd7Oy0u5ca90Rl/UTs4JwEPgUxNFCUXz5ZQ95/dNrwmHuIBtnDjyjWhwdT24c8BWOxpC8d/+wT75fA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      },
-      "peerDependencies": {
-        "@angular/compiler-cli": "^21.0.0",
-        "typescript": ">=5.9 <6.0",
-        "webpack": "^5.54.0"
-      }
-    },
     "node_modules/@noble/hashes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
@@ -15441,9 +15424,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
-      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,7 @@
     "@babel/core": ">=7.29.6",
     "esbuild": ">=0.28.1",
     "http-proxy-middleware": ">=3.0.7",
-    "undici": ">=7.28.0",
+    "undici": "^8.9.0",
     "uuid": ">=11.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- raise the existing transitive Undici override from >=7.28.0 to ^8.9.0
- regenerate the npm lockfile, resolving both tooling paths to Undici 8.10.0
- address Dependabot alerts #304, #305, #306, #307, and #308 without dismissals

## Validation
- clean install: npm ci --legacy-peer-deps succeeds; plain npm ci stalls on existing Angular/TypeScript peer conflicts
- npm ls undici: one deduplicated Undici 8.10.0
- npm audit --omit=dev: 0 vulnerabilities
- npm audit: no Undici findings; 10 unrelated development-tool findings remain
- tests: blocked by existing Babel 8 override and obsolete/missing Angular test APIs
- build: blocked by existing TypeScript 5.6 versus Angular 21 requirement and legacy Ionic Sass imports
- lint: no Angular lint target is configured
- typecheck: no package script is configured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the networking dependency version constraint to improve compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->